### PR TITLE
Nevn nye metadatafelt pronomPUID (M703) og pronomMIME (M704)

### DIFF
--- a/N5/v5.0/arkivstruktur.xsd
+++ b/N5/v5.0/arkivstruktur.xsd
@@ -34,6 +34,8 @@
 			13.2. sakspartNavn er endret til partNavn.
 			13.2. sakspartRolle er endret til partRolle.
     14. Endret version-attributtet i xs:schema fra 3.1 til 5.0.
+    15. M703 - pronomPUID lagt til i dokumentobjekt som valgfri.
+    16. M704 - pronomMIME lagt til i dokumentobjekt som valgfri.
   -->
 
 

--- a/N5/v5.0/metadatakatalog.xsd
+++ b/N5/v5.0/metadatakatalog.xsd
@@ -22,6 +22,8 @@
 	6. Alle felter som krever verdi, krever innhold.
   7. systemID og andre felter som refererer til systemID, krever uuid som data-format. Se simpleType name="ID".
   8. M707 - filstoerrelse endrer datatype fra xs:string til xs:integer.
+  9. M703 - pronomPUID nytt felt.
+ 10. M704 - pronomMIME nytt felt.
   -->
 
 


### PR DESCRIPTION
Omtal nye felt i oversikt over endringer i arkivstruktur.xsd og
metadatakatalog.xsd.

Det burde forklares hvorfor en introduserer pronomPUID i tillegg til
M701 format, i stedet for å definere at format skal inneholde PRONOM
PUID, i og med at format så langt har vært uten definisjon.  Det gjør
at det virker mer fornuftig på meg å definere at format til å inneholde
PRONOM PUID.