### PR TITLE
Bruk konsistent nummerering av metadatafelt (MXXX)

### DIFF
--- a/N5/v5.0/metadatakatalog.xsd
+++ b/N5/v5.0/metadatakatalog.xsd
@@ -58,7 +58,7 @@
 
   <xs:simpleType name="ID">
     <xs:annotation>
-      <xs:documentation>M001-a</xs:documentation>
+      <xs:documentation>M016</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value="[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"/>


### PR DESCRIPTION
Det forenkler maskinell prosessering av Noark 5-relaterte tekster hvis
en kan vite at alle metadatafelt har konsistent identifikator, slik det
har vært i Noark 5 i mange år.  Jeg tenker her på MXXX-formatet, der
alle metadata har en identifikator som består av M fulgt av tre siffer.

I metadatakatalog.xsd for v5.0 er det introdusert et avvik fra dette,
M001-a.  Jeg foreslår at denne heller gis identifikator M016, som er den
første som er ledig i ID-serien (1-19).

Denne M016 bør kanskje også endre navn til UUID, for a gjøre det klart
for alle lesere hva det er slags type ID?