### PR TITLE
Fjern part fra registrering, det holder med korrespondansepart

### DIFF
--- a/N5/v5.0/arkivstruktur.xsd
+++ b/N5/v5.0/arkivstruktur.xsd
@@ -281,7 +281,6 @@
       <xs:element name="arkivertAv" type="n5mdk:arkivertAv"/>
       <xs:element name="referanseArkivdel" type="n5mdk:referanseArkivdel" minOccurs="0" maxOccurs="unbounded"/>
 
-      <xs:element name="part" type="part" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="kassasjon" type="kassasjon" minOccurs="0"/>
       <xs:element name="skjerming" type="skjerming" minOccurs="0"/>
       <xs:element name="gradering" type="gradering" minOccurs="0"/>


### PR DESCRIPTION
Entiteten registrering har fått kobling til både part og
korrespondansepart i arkivstruktur.xsd.  Det gir ikke mening
å knytte juridiske parter til et dokument eller dokumentsamling.
Fjerner derfor part og beholder korrespondansepart.