### PR TITLE
Likt namespace (fjernet /nha fra sti) som for resten av XSDene.

### DIFF
--- a/AVLXML/avlsup-mdk.xsd
+++ b/AVLXML/avlsup-mdk.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xs:schema 	xmlns="http://www.arkivverket.no/standarder/nha/avlxml/avlsup-mdk" 
+<xs:schema 	xmlns="http://www.arkivverket.no/standarder/avlxml/avlsup-mdk" 
 			xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-			targetNamespace="http://www.arkivverket.no/standarder/nha/avlxml/avlsup-mdk" 
+			targetNamespace="http://www.arkivverket.no/standarder/avlxml/avlsup-mdk" 
 			elementFormDefault="qualified">
 
 <!-- 


### PR DESCRIPTION
Dette fjerner feilmelding fra xmllint:

$ xmllint --noout --schema schemas/AVLXML/avlxml.xsd eksempel/xml/avl.xml:
schemas/AVLXML/avlsup.xsd:31: element element: Schemas parser error : element decl. '{http://www.arkivverket.no/standarder/avlxml/avlsup}saksereferansedato', attribute 'type': The QName value '{http://www.arkivverket.no/standarder/avlxml/avlsup-mdk}saksreferansedato' does not resolve to a(n) type definition.
schemas/AVLXML/avlsup.xsd:32: element element: Schemas parser error : element decl. '{http://www.arkivverket.no/standarder/avlxml/avlsup}saksreferansenummer', attribute 'type': The QName value '{http://www.arkivverket.no/standarder/avlxml/avlsup-mdk}saksreferansenummer' does not resolve to a(n) type definition.