### PR TITLE
Gjør journalpost til undertype av arkivnotat

### DIFF
--- a/N5/v5.0/arkivstruktur.xsd
+++ b/N5/v5.0/arkivstruktur.xsd
@@ -309,7 +309,7 @@
 
   <xs:complexType name="journalpost">
     <xs:complexContent>
-      <xs:extension base="registrering">
+      <xs:extension base="arkivnotat">
         <xs:sequence>
           <xs:element name="journalaar" type="n5mdk:journalaar"/>
           <xs:element name="journalsekvensnummer" type="n5mdk:journalsekvensnummer"/>
@@ -317,18 +317,8 @@
           <xs:element name="journalposttype" type="n5mdk:journalposttype"/>
           <xs:element name="journalstatus" type="n5mdk:journalstatus"/>
           <xs:element name="journaldato" type="n5mdk:journaldato"/>
-          <xs:element name="dokumentetsDato" type="n5mdk:dokumentetsDato" minOccurs="0"/>
-          <xs:element name="mottattDato" type="n5mdk:mottattDato" minOccurs="0"/>
-          <xs:element name="sendtDato" type="n5mdk:sendtDato" minOccurs="0"/>
-          <xs:element name="forfallsdato" type="n5mdk:forfallsdato" minOccurs="0"/>
-          <xs:element name="offentlighetsvurdertDato" type="n5mdk:offentlighetsvurdertDato" minOccurs="0"/>
-          <xs:element name="antallVedlegg" type="n5mdk:antallVedlegg" minOccurs="0"/>
-          <xs:element name="utlaantDato" type="n5mdk:utlaantDato" minOccurs="0"/>
-          <xs:element name="utlaantTil" type="n5mdk:utlaantTil" minOccurs="0"/>
           <xs:element name="journalenhet" type="n5mdk:journalenhet" minOccurs="0"/>
-
           <xs:element name="avskrivning" type="avskrivning" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element name="dokumentflyt" type="dokumentflyt" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element name="presedens" type="presedens" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element name="elektroniskSignatur" type="elektroniskSignatur" minOccurs="0"/>
         </xs:sequence>


### PR DESCRIPTION
Journalpost inneholder alle attributtene til arkivnotat med samme
multiplisitet, og begge arver i utgangspunktet fra registrering.
Datamodellen kan dermed gjøres enklere ved å la journalpost arve
fra arkivnotat i stedet.