### PR TITLE
Endre M0016 til M016

### DIFF
--- a/N5/latest/metadatakatalog.xsd
+++ b/N5/latest/metadatakatalog.xsd
@@ -172,7 +172,7 @@
 
   <xs:simpleType name="ID">
     <xs:annotation>
-      <xs:documentation>M0016</xs:documentation>
+      <xs:documentation>M016</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value="[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"/>

--- a/N5/v5.0/metadatakatalog.xsd
+++ b/N5/v5.0/metadatakatalog.xsd
@@ -172,7 +172,7 @@
 
   <xs:simpleType name="ID">
     <xs:annotation>
-      <xs:documentation>M0016</xs:documentation>
+      <xs:documentation>M016</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value="[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"/>


### PR DESCRIPTION
Alle andre metadatakatalogoppføringer bruker tre siffer, så det bør
også M016.