### PR TITLE
Added new dokumentobjekt.mimeType field to XSD

### DIFF
--- a/N5/v5.1/arkivstruktur.xsd
+++ b/N5/v5.1/arkivstruktur.xsd
@@ -457,6 +457,7 @@
       <xs:element name="sjekksum" type="n5mdk:sjekksum"/>
       <xs:element name="sjekksumAlgoritme" type="n5mdk:sjekksumAlgoritme"/>
       <xs:element name="filstoerrelse" type="n5mdk:filstoerrelse"/>
+      <xs:element name="mimeType" type="n5mdk:mimeType" minOccurs="0"/>
       <xs:element name="elektroniskSignatur" type="elektroniskSignatur" minOccurs="0"/>
 
       <xs:element name="konvertering" type="konvertering" minOccurs="0" maxOccurs="unbounded"/>

--- a/N5/v5.1/metadatakatalog.xsd
+++ b/N5/v5.1/metadatakatalog.xsd
@@ -1409,4 +1409,13 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="mimeType">
+    <xs:annotation>
+      <xs:documentation>M716</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
 </xs:schema>


### PR DESCRIPTION
It is already listed in Noark 5.  See
https://github.com/arkivverket/noark5-standard/issues/35 ,
https://github.com/arkivverket/noark5-standard/pull/67 and
https://github.com/arkivverket/noark5-tjenestegrensesnitt-standard/issues/77
for related issues.