### PR TITLE
Rename M506 grad to graderingskode

### DIFF
--- a/N5/v5.1/arkivstruktur.xsd
+++ b/N5/v5.1/arkivstruktur.xsd
@@ -536,7 +536,7 @@
 
   <xs:complexType name="gradering">
     <xs:sequence>
-      <xs:element name="grad" type="n5mdk:grad"/>
+      <xs:element name="graderingskode" type="n5mdk:graderingskode"/>
       <xs:element name="graderingsdato" type="n5mdk:graderingsdato"/>
       <xs:element name="gradertAv" type="n5mdk:gradertAv"/>
       <xs:element name="nedgraderingsdato" type="n5mdk:nedgraderingsdato" minOccurs="0"/>

--- a/N5/v5.1/loependeJournal.xsd
+++ b/N5/v5.1/loependeJournal.xsd
@@ -107,7 +107,7 @@
       <xs:element name="avskrivningsmaate" type="n5mdk:avskrivningsmaate" minOccurs="0"/>
       <xs:element name="referanseAvskrivesAvJournalpost" type="n5mdk:referanseAvskrivesAvJournalpost" minOccurs="0"/>
       <xs:element name="tilgangsrestriksjon" type="n5mdk:tilgangsrestriksjon" minOccurs="0"/>
-      <xs:element name="grad" type="n5mdk:grad" minOccurs="0"/>
+      <xs:element name="graderingskode" type="n5mdk:graderingskode" minOccurs="0"/>
       <xs:element name="skjermingshjemmel" type="n5mdk:skjermingshjemmel" minOccurs="0"/>
 
       <xs:element name="korrespondansepart" type="korrespondansepart" maxOccurs="unbounded"/>

--- a/N5/v5.1/metadatakatalog.xsd
+++ b/N5/v5.1/metadatakatalog.xsd
@@ -902,7 +902,7 @@
     <xs:restriction base="xs:date"/>
   </xs:simpleType>
 
-  <xs:simpleType name="grad">
+  <xs:simpleType name="graderingskode">
     <xs:annotation>
       <xs:documentation>M506</xs:documentation>
     </xs:annotation>

--- a/N5/v5.1/offentligJournal.xsd
+++ b/N5/v5.1/offentligJournal.xsd
@@ -103,7 +103,7 @@
       <xs:element name="avskrivningsmaate" type="n5mdk:avskrivningsmaate" minOccurs="0"/>
       <xs:element name="referanseAvskrivesAvJournalpost" type="n5mdk:referanseAvskrivesAvJournalpost" minOccurs="0"/>
       <xs:element name="tilgangsrestriksjon" type="n5mdk:tilgangsrestriksjon" minOccurs="0"/>
-      <xs:element name="grad" type="n5mdk:grad" minOccurs="0"/>
+      <xs:element name="graderingskode" type="n5mdk:graderingskode" minOccurs="0"/>
       <xs:element name="skjermingshjemmel" type="n5mdk:skjermingshjemmel" minOccurs="0"/>
 
       <xs:element name="korrespondansepart" type="korrespondansepart" maxOccurs="unbounded"/>


### PR DESCRIPTION
This change is already done in Noark 5.
Related to https://github.com/arkivverket/noark5-standard/pull/30

Fixes #13