### PR TITLE
Renamed M056 presedensStatus to presedensstatus

### DIFF
--- a/N5/v5.1/arkivstruktur.xsd
+++ b/N5/v5.1/arkivstruktur.xsd
@@ -558,7 +558,7 @@
       <xs:element name="presedensGodkjentAv" type="n5mdk:presedensGodkjentAv" minOccurs="0"/>
       <xs:element name="avsluttetDato" type="n5mdk:avsluttetDato" minOccurs="0"/>
       <xs:element name="avsluttetAv" type="n5mdk:avsluttetAv" minOccurs="0"/>
-      <xs:element name="presedensStatus" type="n5mdk:presedensStatus" minOccurs="0"/>
+      <xs:element name="presedensstatus" type="n5mdk:presedensstatus" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
 

--- a/N5/v5.1/metadatakatalog.xsd
+++ b/N5/v5.1/metadatakatalog.xsd
@@ -291,7 +291,7 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <xs:simpleType name="presedensStatus">
+  <xs:simpleType name="presedensstatus">
     <xs:annotation>
       <xs:documentation>M056</xs:documentation>
     </xs:annotation>


### PR DESCRIPTION
This bring the XSD in line with Noark 5.  The name has been changed
back and forth, but it was concluded in
https://github.com/arkivverket/noark5-standard/issues/56 to use only
lower case letters, and the change to Noark 5 was implemented in
https://github.com/arkivverket/noark5-standard/pull/60 .