### PR TITLE
Added draft national identities to XSD

### DIFF
--- a/N5/v5.1/arkivstruktur.xsd
+++ b/N5/v5.1/arkivstruktur.xsd
@@ -224,6 +224,10 @@
           <xs:element name="referanseSekundaerKlassifikasjon" type="n5mdk:referanseSekundaerKlassifikasjon" minOccurs="0" maxOccurs="unbounded"/>
 
           <xs:element name="presedens" type="presedens" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="matrikkelnummer" type="presedens" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="byggident" type="presedens" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="planident" type="presedens" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="posisjon" type="presedens" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -242,6 +246,8 @@
       <xs:element name="epostadresse" type="n5mdk:epostadresse" minOccurs="0"/>
       <xs:element name="telefonnummer" type="n5mdk:telefonnummer" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="kontaktperson" type="n5mdk:kontaktperson" minOccurs="0"/>
+      <xs:element name="personID" type="n5mdk:personID" minOccurs="0"/>
+      <xs:element name="organisasjonsID" type="n5mdk:organisasjonsID" minOccurs="0"/>
       <xs:element name="virksomhetsspesifikkeMetadata" type="xs:anyType" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
@@ -350,6 +356,8 @@
       <xs:element name="kontaktperson" type="n5mdk:kontaktperson" minOccurs="0"/>
       <xs:element name="administrativEnhet" type="n5mdk:administrativEnhet" minOccurs="0"/>
       <xs:element name="saksbehandler" type="n5mdk:saksbehandler" minOccurs="0"/>
+      <xs:element name="personID" type="n5mdk:personID" minOccurs="0"/>
+      <xs:element name="organisasjonsID" type="n5mdk:organisasjonsID" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
 
@@ -569,6 +577,45 @@
       <xs:element name="elektroniskSignaturVerifisert" type="n5mdk:elektroniskSignaturVerifisert"/>
       <xs:element name="verifisertDato" type="n5mdk:verifisertDato"/>
       <xs:element name="verifisertAv" type="n5mdk:verifisertAv"/>
+    </xs:sequence>
+  </xs:complexType>
+
+
+  <xs:complexType name="matrikkelnummer">
+    <xs:sequence>
+      <xs:element name="kommunenummer" type="n5mdk:kommunenummer" minOccurs="0"/>
+      <xs:element name="gaardsnummer" type="n5mdk:gaardsnummer"/>
+      <xs:element name="bruksnummer" type="n5mdk:bruksnummer"/>
+      <xs:element name="festenummer" type="n5mdk:festenummer" minOccurs="0"/>
+      <xs:element name="seksjonsnummer" type="n5mdk:seksjonsnummer" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+
+  <xs:complexType name="byggident">
+    <xs:sequence>
+      <xs:element name="bygningsnummer" type="n5mdk:bygningsnummer"/>
+      <xs:element name="endringsloepenummer" type="n5mdk:endringsloepenummer" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+
+  <xs:complexType name="planident">
+    <xs:sequence>
+      <xs:element name="landkode" type="n5mdk:landkode" minOccurs="0"/>
+      <xs:element name="fylkesnummer" type="n5mdk:fylkesnummer" minOccurs="0"/>
+      <xs:element name="kommunenummer" type="n5mdk:kommunenummer" minOccurs="0"/>
+      <xs:element name="planidentifikasjon" type="n5mdk:planidentifikasjon"/>
+    </xs:sequence>
+  </xs:complexType>
+
+
+  <xs:complexType name="posisjon">
+    <xs:sequence>
+      <xs:element name="koordinatsystem" type="n5mdk:koordinatsystem"/>
+      <xs:element name="x" type="n5mdk:x"/>
+      <xs:element name="y" type="n5mdk:y"/>
+      <xs:element name="z" type="n5mdk:z" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
 

--- a/N5/v5.1/metadatakatalog.xsd
+++ b/N5/v5.1/metadatakatalog.xsd
@@ -235,6 +235,136 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="kommunenummer">
+    <xs:annotation>
+      <xs:documentation>M030</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="gaardsnummer">
+    <xs:annotation>
+      <xs:documentation>M031</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:integer"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="bruksnummer">
+    <xs:annotation>
+      <xs:documentation>M032</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:integer"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="festenummer">
+    <xs:annotation>
+      <xs:documentation>M033</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:integer"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="seksjonsnummer">
+    <xs:annotation>
+      <xs:documentation>M034</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:integer"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="bygningsnummer">
+    <xs:annotation>
+      <xs:documentation>M035</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:integer"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="endringsloepenummer">
+    <xs:annotation>
+      <xs:documentation>M036</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:integer"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="fylkesnummer">
+    <xs:annotation>
+      <xs:documentation>M037</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:integer"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="landkode">
+    <xs:annotation>
+      <xs:documentation>M038</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="planidentifikasjon">
+    <xs:annotation>
+      <xs:documentation>M039</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="x">
+    <xs:annotation>
+      <xs:documentation>M040</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="y">
+    <xs:annotation>
+      <xs:documentation>M041</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="z">
+    <xs:annotation>
+      <xs:documentation>M042</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="koordinatsystem">
+    <xs:annotation>
+      <xs:documentation>M043</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="personID">
+    <xs:annotation>
+      <xs:documentation>M048</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="organisasjonsID">
+    <xs:annotation>
+      <xs:documentation>M049</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <!-- M050-M079: Status -->
 
   <xs:simpleType name="arkivstatus">


### PR DESCRIPTION
The current description in Noark 5 do not match the description in
Noark 5 Tjenestegrensesnitt.

This change is related to
https://github.com/arkivverket/noark5-standard/issues/53 ,
https://github.com/arkivverket/noark5-standard/issues/77 ,
https://github.com/arkivverket/noark5-standard/pull/93 and
https://github.com/arkivverket/noark5-tjenestegrensesnitt-standard/issues/141 .