### PR TITLE
Added new konvertering attributes for checksums

### DIFF
--- a/N5/v5.1/arkivstruktur.xsd
+++ b/N5/v5.1/arkivstruktur.xsd
@@ -478,6 +478,10 @@
       <xs:element name="konvertertAv" type="n5mdk:konvertertAv"/>
       <xs:element name="konvertertFraFormat" type="n5mdk:konvertertFraFormat"/>
       <xs:element name="konvertertTilFormat" type="n5mdk:konvertertTilFormat"/>
+      <xs:element name="konvertertFraSjekksum" type="n5mdk:konvertertFraSjekksum" minOccurs="0"/>
+      <xs:element name="konvertertFraSjekksumAlgoritme" type="n5mdk:konvertertFraSjekksumAlgoritme" minOccurs="0"/>
+      <xs:element name="konvertertTilSjekksum" type="n5mdk:konvertertTilSjekksum" minOccurs="0"/>
+      <xs:element name="konvertertTilSjekksumAlgoritme" type="n5mdk:konvertertTilSjekksumAlgoritme" minOccurs="0"/>
       <xs:element name="konverteringsverktoey" type="n5mdk:konverteringsverktoey" minOccurs="0"/>
       <xs:element name="konverteringskommentar" type="n5mdk:konverteringskommentar" minOccurs="0"/>
     </xs:sequence>

--- a/N5/v5.1/metadatakatalog.xsd
+++ b/N5/v5.1/metadatakatalog.xsd
@@ -1539,4 +1539,40 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="konvertertFraSjekksum">
+    <xs:annotation>
+      <xs:documentation>M717</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="konvertertFraSjekksumAlgoritme">
+    <xs:annotation>
+      <xs:documentation>M718</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="konvertertTilSjekksum">
+    <xs:annotation>
+      <xs:documentation>M719</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="konvertertFraSjekksumAlgoritme">
+    <xs:annotation>
+      <xs:documentation>M720</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
 </xs:schema>


### PR DESCRIPTION
The new attributes were added to Noark 5 in
https://github.com/arkivverket/noark5-standard/commit/4f982f901024349fdec3e6a148910321c7db73fd .