### PR TITLE
Change workflows to push to public acr using OIDC auth

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,13 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Login to Docker container registry
-        uses: docker/login-action@v3.6.0
-        with:
-          registry: arkivverket.azurecr.io
-          username: ${{ secrets.ARKIVVERKET_AZURE_REGISTRY_USERNAME }}
-          password: ${{ secrets.ARKIVVERKET_AZURE_REGISTRY_PASSWORD }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.12.0
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
     types: [closed]
 
 env:
-  ACR: arkivverket.azurecr.io/schemas
+  ACR: arkivverketpublic.azurecr.io/schemas
   IMAGE: schemas
   TARGET_ENV: karbonprod
 
@@ -25,17 +25,23 @@ jobs:
   build-and-publish-image:
     runs-on: ubuntu-latest
     needs: pre_job
+    permissions:
+      id-token: write
+      contents: read
     env:
       IMAGE_VERSION: ${{ format('{0}-{1}', needs.pre_job.outputs.date, github.sha) }}
     steps:
       - uses: actions/checkout@v6
 
-      - name: Login to Docker container registry
-        uses: docker/login-action@v3.6.0
+      - name: Authenticate to Azure (OIDC)
+        uses: azure/login@v3
         with:
-          registry: arkivverket.azurecr.io
-          username: ${{ secrets.ARKIVVERKET_AZURE_REGISTRY_USERNAME }}
-          password: ${{ secrets.ARKIVVERKET_AZURE_REGISTRY_PASSWORD }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Log in to ACR
+        run: az acr login --name arkivverketpublic
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.12.0


### PR DESCRIPTION
[ITP-1931]

- Stop using passwords in github secrets
- Use short lived tokens with oidc

Needed for this: 

     AZURE_CLIENT_ID
     AZURE_TENANT_ID
     AZURE_SUBSCRIPTION_ID

[ITP-1931]: https://arkivverket.atlassian.net/browse/ITP-1931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ