### PR TITLE
Publish image version as a git tag instead of a GitHub Release

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -55,12 +55,11 @@ jobs:
           --push .
         working-directory: .
 
-      - name: Record deployed image tag as a release
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Tag the build with the pushed image version
         run: |
-          gh release view "${IMAGE_VERSION}" >/dev/null 2>&1 || \
-          gh release create "${IMAGE_VERSION}" \
-            --target "${GITHUB_SHA}" \
-            --title "${IMAGE_VERSION}" \
-            --notes "Pushed ${ACR}/${IMAGE}:${IMAGE_VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${IMAGE_VERSION}" >/dev/null 2>&1; then
+            echo "Tag ${IMAGE_VERSION} already exists; nothing to do."
+          else
+            git tag "${IMAGE_VERSION}"
+            git push origin "${IMAGE_VERSION}"
+          fi


### PR DESCRIPTION
[ITP-1931]

[ITP-1931]: https://arkivverket.atlassian.net/browse/ITP-1931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ